### PR TITLE
Use DriverManager/getConnection() instead of DriverManager/getDriver()

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject metabase/connection-pool "1.1.0"
+(defproject metabase/connection-pool "1.1.1"
   :description "Connection pools for JDBC databases. Simple wrapper around C3P0."
   :url "https://github.com/metabase/connection-pool"
   :min-lein-version "2.5.0"


### PR DESCRIPTION
The `proxy-data-source` should call `(DriverManager/getConnection url props) instead of `(.connect (DriverManager/getDriver url) url props)`, because the props may affect which driver is used. Specifically, the Redshift JDBC driver will attempt to accept any `jdbc:postgresql:` URLs unless `OpenSourceSubProtocolOverride=true` is set. If this is set in the `Properties`, rather than as a query param in the JDBC URL, we could incorrectly use the Redshift JDBC driver for Postgres connections